### PR TITLE
 Make it possible to create regular expressions programmatically

### DIFF
--- a/src/Builder/ExpressionBuilder.php
+++ b/src/Builder/ExpressionBuilder.php
@@ -2,14 +2,8 @@
 
 namespace Spatie\Regex\Builder;
 
-/**
- * Class ExpressionBuilder
- *
- * @package Spatie\Regex\Builder
- */
 class ExpressionBuilder
 {
-
     /**
      * @return ExpressionBuilder
      */
@@ -177,7 +171,7 @@ class ExpressionBuilder
      */
     public function lazyOneOrMoreTimes(): string
     {
-        return $this->oneOrMoreTimes() . '?';
+        return $this->oneOrMoreTimes().'?';
     }
 
     /**
@@ -199,7 +193,7 @@ class ExpressionBuilder
      */
     public function lazyBetweenTimes(int $n, int $m): string
     {
-        return $this->betweenTimes($n, $m) . '?';
+        return $this->betweenTimes($n, $m).'?';
     }
 
     /**
@@ -213,7 +207,7 @@ class ExpressionBuilder
     }
 
     /**
-     * This method requires the free spaces modifier 'x'
+     * This method requires the free spaces modifier 'x'.
      *
      * @param string $comment
      *
@@ -240,7 +234,7 @@ class ExpressionBuilder
      *
      * @return string
      */
-    public function alternate(... $expressions): string
+    public function alternate(...$expressions): string
     {
         return implode('|', $expressions);
     }
@@ -250,7 +244,7 @@ class ExpressionBuilder
      *
      * @return string
      */
-    public function concat(... $expressions): string
+    public function concat(...$expressions): string
     {
         return implode('', $expressions);
     }

--- a/src/Builder/ExpressionBuilder.php
+++ b/src/Builder/ExpressionBuilder.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Spatie\Regex\Builder;
+
+/**
+ * Class ExpressionBuilder
+ *
+ * @package Spatie\Regex\Builder
+ */
+class ExpressionBuilder
+{
+
+    /**
+     * @return ExpressionBuilder
+     */
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    /**
+     * @param $characters
+     *
+     * @return string
+     */
+    public function characterClass($characters): string
+    {
+        return sprintf('[%s]', $characters);
+    }
+
+    /**
+     * @param string $from
+     * @param string $to
+     *
+     * @return string
+     */
+    public function range(string $from, string $to): string
+    {
+        return sprintf('%s-%s', $from, $to);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public function group(string $pattern): string
+    {
+        return sprintf('(%s)', $pattern);
+    }
+
+    /**
+     * @param string $name
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public function namedGroup(string $name, string $pattern): string
+    {
+        return $this->group(sprintf('?P<%s>%s', $name, $pattern));
+    }
+
+    /**
+     * @param int $groupNumber
+     *
+     * @return string
+     */
+    public function backReferenceToNumericGroup(int $groupNumber): string
+    {
+        return sprintf('\%s', $groupNumber);
+    }
+
+    /**
+     * @param string $groupName
+     *
+     * @return string
+     */
+    public function backReferenceToNamedGroup(string $groupName): string
+    {
+        return sprintf('(?P=%s)', $groupName);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public function startsWith(string $pattern): string
+    {
+        return sprintf('^%s', $pattern);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public function endsWith(string $pattern): string
+    {
+        return sprintf('%s$', $pattern);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public function lookBehind(string $pattern): string
+    {
+        return sprintf('(?<=%s)', $pattern);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public function lookAhead(string $pattern): string
+    {
+        return sprintf('(?=%s)', $pattern);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public function lookNotBehind(string $pattern): string
+    {
+        return sprintf('(?<!%s)', $pattern);
+    }
+
+    /**
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public function lookNotAhead(string $pattern): string
+    {
+        return sprintf('(?!%s)', $pattern);
+    }
+
+    /**
+     * @return string
+     */
+    public function zeroOrOneTimes(): string
+    {
+        return '?';
+    }
+
+    /**
+     * @return string
+     */
+    public function zeroOrMoreTimes(): string
+    {
+        return '*';
+    }
+
+    /**
+     * @return string
+     */
+    public function oneOrMoreTimes(): string
+    {
+        return '+';
+    }
+
+    /**
+     * @return string
+     */
+    public function possesiveOneOrMoreTimes(): string
+    {
+        return '++';
+    }
+
+    /**
+     * @return string
+     */
+    public function lazyOneOrMoreTimes(): string
+    {
+        return $this->oneOrMoreTimes() . '?';
+    }
+
+    /**
+     * @param int $n
+     * @param int $m
+     *
+     * @return string
+     */
+    public function betweenTimes(int $n, int $m): string
+    {
+        return sprintf('{%s,%s}', $n, $m);
+    }
+
+    /**
+     * @param int $n
+     * @param int $m
+     *
+     * @return string
+     */
+    public function lazyBetweenTimes(int $n, int $m): string
+    {
+        return $this->betweenTimes($n, $m) . '?';
+    }
+
+    /**
+     * @param string $comment
+     *
+     * @return string
+     */
+    public function comment(string $comment): string
+    {
+        return sprintf('(?# %s)', str_replace(')', '\\)', $comment));
+    }
+
+    /**
+     * This method requires the free spaces modifier 'x'
+     *
+     * @param string $comment
+     *
+     * @return string
+     */
+    public function extendedComment(string $comment): string
+    {
+        return sprintf('# %s', $comment);
+    }
+
+    /**
+     * @param string      $raw
+     * @param string|null $delimiter
+     *
+     * @return string
+     */
+    public function escape(string $raw, string $delimiter = null): string
+    {
+        return preg_quote($raw, $delimiter);
+    }
+
+    /**
+     * @param array ...$expressions
+     *
+     * @return string
+     */
+    public function alternate(... $expressions): string
+    {
+        return implode('|', $expressions);
+    }
+
+    /**
+     * @param array ...$expressions
+     *
+     * @return string
+     */
+    public function concat(... $expressions): string
+    {
+        return implode('', $expressions);
+    }
+}

--- a/src/Builder/RegexBuilder.php
+++ b/src/Builder/RegexBuilder.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Spatie\Regex\Builder;
+
+use Spatie\Regex\Regex;
+use Spatie\Regex\RegexFailed;
+
+/**
+ * Class RegexBuilder
+ *
+ * @package Spatie\Regex\Builder
+ */
+class RegexBuilder
+{
+
+    const DEFAULT_DELIMITER = '/';
+
+    /**
+     * @var string
+     */
+    private $startDelimiter = self::DEFAULT_DELIMITER;
+
+    /**
+     * @var string
+     */
+    private $endDelimiter = self::DEFAULT_DELIMITER;
+
+    /**
+     * @var array
+     */
+    private $modifiers = [];
+
+    /**
+     * @var string
+     */
+    private $startsWith = '';
+
+    /**
+     * @var string
+     */
+    private $endsWith = '';
+
+    /**
+     * @var array|string[]
+     */
+    private $expressions = [];
+
+    /**
+     * @var string
+     */
+    private $delimiter = '';
+
+    /**
+     * RegexBuilder constructor.
+     *
+     * @param array  $parts
+     * @param string $delimiter
+     * @param array  $modifiers
+     */
+    public function __construct(array $parts = [], $delimiter = self::DEFAULT_DELIMITER, array $modifiers = [])
+    {
+        $this->parts = $parts;
+        $this->setDelimiter($delimiter);
+        $this->addModifiers($modifiers);
+    }
+
+    /**
+     * @param array  $parts
+     * @param string $delimiter
+     * @param array  $modifiers
+     *
+     * @return RegexBuilder
+     */
+    public static function create(array $parts = [], $delimiter = self::DEFAULT_DELIMITER, array $modifiers = []): self
+    {
+        return new self($parts, $delimiter, $modifiers);
+    }
+
+    /**
+     * @param string $part
+     *
+     * @return RegexBuilder
+     */
+    public function startsWith(string $part): self
+    {
+        $this->startsWith = $part;
+
+        return $this;
+    }
+
+    /**
+     * @param string $part
+     *
+     * @return RegexBuilder
+     */
+    public function endsWith(string $part): self
+    {
+        $this->endsWith = $part;
+
+        return $this;
+    }
+
+    /**
+     * @param string $expression
+     *
+     * @return RegexBuilder
+     */
+    public function addExpression(string $expression) : self
+    {
+        $this->expressions[] = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @param string $modifier
+     *
+     * @return RegexBuilder
+     * @throws \Spatie\Regex\RegexFailed
+     */
+    public function addModifier(string $modifier): self
+    {
+        if (strlen($modifier) !== 1 || false === strpos(Regex::MODIFIERS_ALL, $modifier)) {
+            throw new RegexFailed('Invalid regex modifier: ' . $modifier);
+        }
+
+        if ($this->hasModifier($modifier)) {
+            return $this;
+        }
+
+        $this->modifiers[] = $modifier;
+        return $this;
+    }
+
+    /**
+     * @param array|string[] $modifiers
+     *
+     * @return RegexBuilder
+     */
+    public function addModifiers(array $modifiers): self
+    {
+        foreach ($modifiers as $modifier) {
+            $this->addModifier($modifier);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return RegexBuilder
+     */
+    public function isCaseInsensitive(): self
+    {
+        $this->addModifier(Regex::MODIFIER_CASE_INSENSITIVE);
+
+        return $this;
+    }
+
+    /**
+     * @return RegexBuilder
+     */
+    public function isMultiline(): self
+    {
+        $this->addModifier(Regex::MODIFIER_MULTILINE);
+
+        return $this;
+    }
+
+    /**
+     * @return RegexBuilder
+     */
+    public function isFreeSpacing(): self
+    {
+        $this->addModifier(Regex::MODIFIER_FREE_SPACING_MODE);
+
+        return $this;
+    }
+
+    /**
+     * @return RegexBuilder
+     */
+    public function isUnicode(): self
+    {
+        $this->addModifier(Regex::MODIFIER_UNICODE);
+
+        return $this;
+    }
+
+    /**
+     * @param string $modifier
+     *
+     * @return bool
+     */
+    public function hasModifier(string $modifier): bool
+    {
+        return in_array($modifier, $this->modifiers);
+    }
+
+    /**
+     * @param string $modifier
+     *
+     * @return RegexBuilder
+     */
+    public function removeModifier(string $modifier): self
+    {
+        if (!$this->hasModifier($modifier)) {
+            return $this;
+        }
+
+        $this->modifiers = array_diff($this->modifiers, [$modifier]);
+
+        return $this;
+    }
+
+    /**
+     * @param string $delimiter
+     *
+     * @return RegexBuilder
+     * @throws \Spatie\Regex\RegexFailed
+     */
+    public function setDelimiter(string $delimiter): self
+    {
+        if (strlen($delimiter) !== 1) {
+            throw new RegexFailed('Invalid regex delimiter: ' . $delimiter);
+        }
+
+        $bracketPos = strpos(Regex::DELIMITER_BRACKET_STYLE_START, $delimiter);
+
+        $this->startDelimiter = $delimiter;
+        $this->endDelimiter = ($bracketPos !== false) ? Regex::DELIMITER_BRACKET_STYLE_END[$bracketPos] : $delimiter;
+
+        return $this;
+    }
+
+    /**
+     * @param string $glue
+     *
+     * @return string
+     * @throws RegexFailed
+     */
+    public function getRegex(string $glue = ''): string
+    {
+        $parts = $this->expressions;
+        array_unshift($parts, $this->startsWith);
+        array_push($parts, $this->endsWith);
+
+        $meta = $this->startDelimiter . '%2$s%1$s%2$s' . $this->endDelimiter . implode('', $this->modifiers);
+        $expression = implode($glue, array_filter($parts));
+        $pattern = sprintf($meta, $expression, $glue);
+
+        // Test the regular expression (which throws a RegexFailed on invalid regex)
+        // Todo: custom error?
+        Regex::match($pattern, '');
+
+        return $pattern;
+    }
+}

--- a/src/Builder/RegexBuilder.php
+++ b/src/Builder/RegexBuilder.php
@@ -121,7 +121,7 @@ class RegexBuilder
     public function addModifier(string $modifier): self
     {
         if (strlen($modifier) !== 1 || false === strpos(Regex::MODIFIERS_ALL, $modifier)) {
-            throw new RegexFailed('Invalid regex modifier: ' . $modifier);
+            throw RegexFailed::invalidModifier($modifier);
         }
 
         if ($this->hasModifier($modifier)) {
@@ -221,7 +221,7 @@ class RegexBuilder
     public function setDelimiter(string $delimiter): self
     {
         if (strlen($delimiter) !== 1) {
-            throw new RegexFailed('Invalid regex delimiter: ' . $delimiter);
+            throw RegexFailed::invalidDelimiter($delimiter);
         }
 
         $bracketPos = strpos(Regex::DELIMITER_BRACKET_STYLE_START, $delimiter);

--- a/src/Builder/RegexBuilder.php
+++ b/src/Builder/RegexBuilder.php
@@ -5,14 +5,8 @@ namespace Spatie\Regex\Builder;
 use Spatie\Regex\Regex;
 use Spatie\Regex\RegexFailed;
 
-/**
- * Class RegexBuilder
- *
- * @package Spatie\Regex\Builder
- */
 class RegexBuilder
 {
-
     const DEFAULT_DELIMITER = '/';
 
     /**
@@ -46,34 +40,29 @@ class RegexBuilder
     private $expressions = [];
 
     /**
-     * @var string
-     */
-    private $delimiter = '';
-
-    /**
      * RegexBuilder constructor.
      *
-     * @param array  $parts
+     * @param array  $expressions
      * @param string $delimiter
      * @param array  $modifiers
      */
-    public function __construct(array $parts = [], $delimiter = self::DEFAULT_DELIMITER, array $modifiers = [])
+    public function __construct(array $expressions = [], $delimiter = self::DEFAULT_DELIMITER, array $modifiers = [])
     {
-        $this->parts = $parts;
+        $this->expressions = $expressions;
         $this->setDelimiter($delimiter);
         $this->addModifiers($modifiers);
     }
 
     /**
-     * @param array  $parts
+     * @param array  $expressions
      * @param string $delimiter
      * @param array  $modifiers
      *
      * @return RegexBuilder
      */
-    public static function create(array $parts = [], $delimiter = self::DEFAULT_DELIMITER, array $modifiers = []): self
+    public static function create(array $expressions = [], $delimiter = self::DEFAULT_DELIMITER, array $modifiers = []): self
     {
-        return new self($parts, $delimiter, $modifiers);
+        return new self($expressions, $delimiter, $modifiers);
     }
 
     /**
@@ -129,6 +118,7 @@ class RegexBuilder
         }
 
         $this->modifiers[] = $modifier;
+
         return $this;
     }
 
@@ -203,7 +193,7 @@ class RegexBuilder
      */
     public function removeModifier(string $modifier): self
     {
-        if (!$this->hasModifier($modifier)) {
+        if (! $this->hasModifier($modifier)) {
             return $this;
         }
 
@@ -244,7 +234,7 @@ class RegexBuilder
         array_unshift($parts, $this->startsWith);
         array_push($parts, $this->endsWith);
 
-        $meta = $this->startDelimiter . '%2$s%1$s%2$s' . $this->endDelimiter . implode('', $this->modifiers);
+        $meta = $this->startDelimiter.'%2$s%1$s%2$s'.$this->endDelimiter.implode('', $this->modifiers);
         $expression = implode($glue, array_filter($parts));
         $pattern = sprintf($meta, $expression, $glue);
 

--- a/src/MatchResult.php
+++ b/src/MatchResult.php
@@ -72,4 +72,19 @@ class MatchResult extends RegexResult
 
         return $this->matches[$index];
     }
+
+    /**
+     * @param string $group
+     *
+     * @return string
+     * @throws RegexFailed
+     */
+    public function namedGroup(string $group): string
+    {
+        if (! isset($this->matches[$group])) {
+            throw RegexFailed::namedGroupDoesntExist($this->pattern, $this->subject, $group);
+        }
+
+        return $this->matches[$group];
+    }
 }

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -5,6 +5,42 @@ namespace Spatie\Regex;
 class Regex
 {
     /**
+     * Modifiers
+     * @see http://php.net/manual/en/reference.pcre.pattern.modifiers.php
+     */
+    const MODIFIERS_ALL = 'imsxuADU';
+    const MODIFIER_CASE_INSENSITIVE = 'i';
+    const MODIFIER_MULTILINE = 'm';
+    const MODIFIER_SINGLE_LINE = 's';
+    const MODIFIER_DOTALL = self::MODIFIER_SINGLE_LINE;
+    const MODIFIER_UNICODE = 'u';
+    const MODIFIER_DOLLAR_END_ONLY = 'z';
+    const MODIFIER_FREE_SPACING_MODE = 'x';
+    const MODIFIER_PCRE_ANCHORED = 'A';
+    const MODIFIER_PCRE_DOLLAR_ENDONLY = 'D';
+    const MODIFIER_PCRE_UNGREEDY = 'U';
+
+    /**
+     * Delimiters
+     * @see http://php.net/manual/en/regexp.reference.delimiters.php
+     */
+    const DELIMITER_BRACKET_STYLE_START = '({[<';
+    const DELIMITER_BRACKET_STYLE_END = ')}]>';
+
+    /** Meta characters */
+    const META_WORD = '\w';
+    const META_WHITESPACE = '\s';
+    const META_DIGIT = '\d';
+    const META_WORD_BOUNDARY = '\b';
+    const META_NOT_WORD = '\W';
+    const META_NOT_WHITESPACE = '\S';
+    const META_NOT_DIGIT = '\D';
+
+    /** Anchor characters */
+    const ANCHOR_ABSOLUTE_BEGINNING = '\A';
+    const ANCHOR_ABSOLUTE_ENDING = '\z';
+
+    /**
      * @param string $pattern
      * @param string $subject
      *

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -5,7 +5,7 @@ namespace Spatie\Regex;
 class Regex
 {
     /**
-     * Modifiers
+     * Modifiers.
      * @see http://php.net/manual/en/reference.pcre.pattern.modifiers.php
      */
     const MODIFIERS_ALL = 'imsxuADU';
@@ -21,7 +21,7 @@ class Regex
     const MODIFIER_PCRE_UNGREEDY = 'U';
 
     /**
-     * Delimiters
+     * Delimiters.
      * @see http://php.net/manual/en/regexp.reference.delimiters.php
      */
     const DELIMITER_BRACKET_STYLE_START = '({[<';

--- a/src/RegexFailed.php
+++ b/src/RegexFailed.php
@@ -25,6 +25,11 @@ class RegexFailed extends Exception
         return new static("Pattern `{$pattern}` with subject `{$subject}` didn't capture a group at index {$index}");
     }
 
+    public static function namedGroupDoesntExist(string $pattern, string $subject, string $group): self
+    {
+        return new static("Pattern `{$pattern}` with subject `{$subject}` didn't capture a group with name {$group}");
+    }
+
     protected static function trimString(string $string): string
     {
         if (strlen($string) < 40) {

--- a/src/RegexFailed.php
+++ b/src/RegexFailed.php
@@ -30,6 +30,26 @@ class RegexFailed extends Exception
         return new static("Pattern `{$pattern}` with subject `{$subject}` didn't capture a group with name {$group}");
     }
 
+    /**
+     * @param string $modifier
+     *
+     * @return RegexFailed
+     */
+    public static function invalidModifier(string $modifier): self
+    {
+        return new static("Invalid delimiter: {$modifier}");
+    }
+
+    /**
+     * @param string $delimiter
+     *
+     * @return RegexFailed
+     */
+    public static function invalidDelimiter(string $delimiter): self
+    {
+        return new static("Invalid delimiter: {$delimiter}");
+    }
+
     protected static function trimString(string $string): string
     {
         if (strlen($string) < 40) {

--- a/tests/ExpressionBuilderTest.php
+++ b/tests/ExpressionBuilderTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Spatie\Regex\Test;
+
+use Spatie\Regex\Builder\ExpressionBuilder;
+
+class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    function it_builds_character_classes()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('[a-z]', $exp->characterClass('a-z'));
+        $this->assertEquals('[a-zA-Z]', $exp->characterClass('a-zA-Z'));
+    }
+
+    /** @test */
+    function it_builds_ranges()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('a-z', $exp->range('a', 'z'));
+        $this->assertEquals('0-9', $exp->range('0', '9'));
+    }
+
+    /** @test */
+    function it_builds_groups()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('(.*)', $exp->group('.*'));
+    }
+
+    /** @test */
+    function it_builds_named_groups()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('(?P<mygroup>.*)', $exp->namedGroup('mygroup', '.*'));
+    }
+
+    /** @test */
+    function it_builds_back_reference_to_numeric_group()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('\1', $exp->backReferenceToNumericGroup(1));
+    }
+
+    /** @test */
+    function it_builds_back_reference_to_named_group()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('(?P=mygroup)', $exp->backReferenceToNamedGroup('mygroup'));
+    }
+
+    /** @test */
+    function it_builds_starting_patterns()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('^start', $exp->startsWith('start'));
+    }
+
+    /** @test */
+    function it_builds_ending_patterns()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('end$', $exp->endsWith('end'));
+    }
+
+    /** @test */
+    function it_builds_look_behind_patterns()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('(?<=_)', $exp->lookBehind('_'));
+    }
+
+    /** @test */
+    function it_builds_look_ahead_patterns()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('(?=_)', $exp->lookAhead('_'));
+    }
+
+    /** @test */
+    function it_builds_look_not_behind_patterns()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('(?<!_)', $exp->lookNotBehind('_'));
+    }
+
+    /** @test */
+    function it_builds_look_not_ahead_patterns()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('(?!_)', $exp->lookNotAhead('_'));
+    }
+
+    /** @test */
+    function it_builds_quantifier_zero_or_one_times()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('?', $exp->zeroOrOneTimes());
+    }
+
+    /** @test */
+    function it_builds_quantifier_zero_or_more_times()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('*', $exp->zeroOrMoreTimes());
+    }
+
+    /** @test */
+    function it_builds_quantifier_one_or_more_times()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('+', $exp->oneOrMoreTimes());
+    }
+
+    /** @test */
+    function it_builds_quantifier_possesive_one_or_more_times()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('++', $exp->possesiveOneOrMoreTimes());
+    }
+
+    /** @test */
+    function it_builds_lazy_quantifier_one_or_more_times()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('+?', $exp->lazyOneOrMoreTimes());
+    }
+
+    /** @test */
+    function it_builds_quantifier_between_times()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('{1,2}', $exp->betweenTimes(1, 2));
+    }
+
+    /** @test */
+    function it_builds_quantifier_lazy_between_times()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('{1,2}?', $exp->lazyBetweenTimes(1, 2));
+    }
+
+    /** @test */
+    function it_builds_comments()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('(?# comment)', $exp->comment('comment'));
+        $this->assertEquals('(?# comment (brackets\))', $exp->comment('comment (brackets)'));
+    }
+
+    /** @test */
+    function it_builds_extended_comments()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('# comment', $exp->extendedComment('comment'));
+        $this->assertEquals('# comment (brackets)', $exp->extendedComment('comment (brackets)'));
+    }
+
+    /** @test */
+    function it_builds_escaped_expressions()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('\*', $exp->escape('*'));
+        $this->assertEquals('\\\\', $exp->escape('\\'));
+        $this->assertEquals('something', $exp->escape('something'));
+        $this->assertEquals('\/', $exp->escape('/', '/'));
+    }
+
+    /** @test */
+    function it_builds_alternating_values()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('value1', $exp->alternate('value1'));
+        $this->assertEquals('value1|value2', $exp->alternate('value1', 'value2'));
+    }
+
+
+    /** @test */
+    function it_concats_expression_parts()
+    {
+        $exp = ExpressionBuilder::create();
+        $this->assertEquals('[0-9a-z]*', $exp->concat(
+            $exp->characterClass(
+                $exp->concat(
+                    $exp->range('0', '9'),
+                    $exp->range('a', 'z')
+                )
+            ),
+            $exp->zeroOrMoreTimes()
+        ));
+    }
+}

--- a/tests/ExpressionBuilderTest.php
+++ b/tests/ExpressionBuilderTest.php
@@ -7,7 +7,7 @@ use Spatie\Regex\Builder\ExpressionBuilder;
 class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
 {
     /** @test */
-    function it_builds_character_classes()
+    public function it_builds_character_classes()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('[a-z]', $exp->characterClass('a-z'));
@@ -15,7 +15,7 @@ class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_builds_ranges()
+    public function it_builds_ranges()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('a-z', $exp->range('a', 'z'));
@@ -23,126 +23,126 @@ class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_builds_groups()
+    public function it_builds_groups()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('(.*)', $exp->group('.*'));
     }
 
     /** @test */
-    function it_builds_named_groups()
+    public function it_builds_named_groups()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('(?P<mygroup>.*)', $exp->namedGroup('mygroup', '.*'));
     }
 
     /** @test */
-    function it_builds_back_reference_to_numeric_group()
+    public function it_builds_back_reference_to_numeric_group()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('\1', $exp->backReferenceToNumericGroup(1));
     }
 
     /** @test */
-    function it_builds_back_reference_to_named_group()
+    public function it_builds_back_reference_to_named_group()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('(?P=mygroup)', $exp->backReferenceToNamedGroup('mygroup'));
     }
 
     /** @test */
-    function it_builds_starting_patterns()
+    public function it_builds_starting_patterns()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('^start', $exp->startsWith('start'));
     }
 
     /** @test */
-    function it_builds_ending_patterns()
+    public function it_builds_ending_patterns()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('end$', $exp->endsWith('end'));
     }
 
     /** @test */
-    function it_builds_look_behind_patterns()
+    public function it_builds_look_behind_patterns()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('(?<=_)', $exp->lookBehind('_'));
     }
 
     /** @test */
-    function it_builds_look_ahead_patterns()
+    public function it_builds_look_ahead_patterns()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('(?=_)', $exp->lookAhead('_'));
     }
 
     /** @test */
-    function it_builds_look_not_behind_patterns()
+    public function it_builds_look_not_behind_patterns()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('(?<!_)', $exp->lookNotBehind('_'));
     }
 
     /** @test */
-    function it_builds_look_not_ahead_patterns()
+    public function it_builds_look_not_ahead_patterns()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('(?!_)', $exp->lookNotAhead('_'));
     }
 
     /** @test */
-    function it_builds_quantifier_zero_or_one_times()
+    public function it_builds_quantifier_zero_or_one_times()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('?', $exp->zeroOrOneTimes());
     }
 
     /** @test */
-    function it_builds_quantifier_zero_or_more_times()
+    public function it_builds_quantifier_zero_or_more_times()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('*', $exp->zeroOrMoreTimes());
     }
 
     /** @test */
-    function it_builds_quantifier_one_or_more_times()
+    public function it_builds_quantifier_one_or_more_times()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('+', $exp->oneOrMoreTimes());
     }
 
     /** @test */
-    function it_builds_quantifier_possesive_one_or_more_times()
+    public function it_builds_quantifier_possesive_one_or_more_times()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('++', $exp->possesiveOneOrMoreTimes());
     }
 
     /** @test */
-    function it_builds_lazy_quantifier_one_or_more_times()
+    public function it_builds_lazy_quantifier_one_or_more_times()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('+?', $exp->lazyOneOrMoreTimes());
     }
 
     /** @test */
-    function it_builds_quantifier_between_times()
+    public function it_builds_quantifier_between_times()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('{1,2}', $exp->betweenTimes(1, 2));
     }
 
     /** @test */
-    function it_builds_quantifier_lazy_between_times()
+    public function it_builds_quantifier_lazy_between_times()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('{1,2}?', $exp->lazyBetweenTimes(1, 2));
     }
 
     /** @test */
-    function it_builds_comments()
+    public function it_builds_comments()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('(?# comment)', $exp->comment('comment'));
@@ -150,7 +150,7 @@ class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_builds_extended_comments()
+    public function it_builds_extended_comments()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('# comment', $exp->extendedComment('comment'));
@@ -158,7 +158,7 @@ class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_builds_escaped_expressions()
+    public function it_builds_escaped_expressions()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('\*', $exp->escape('*'));
@@ -168,16 +168,15 @@ class ExpressionBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_builds_alternating_values()
+    public function it_builds_alternating_values()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('value1', $exp->alternate('value1'));
         $this->assertEquals('value1|value2', $exp->alternate('value1', 'value2'));
     }
 
-
     /** @test */
-    function it_concats_expression_parts()
+    public function it_concats_expression_parts()
     {
         $exp = ExpressionBuilder::create();
         $this->assertEquals('[0-9a-z]*', $exp->concat(

--- a/tests/MatchTest.php
+++ b/tests/MatchTest.php
@@ -78,5 +78,4 @@ class MatchTest extends PHPUnit_Framework_TestCase
 
         Regex::match('/(?P<mygroup>a)bc/', 'abcdef')->namedGroup('othergroup');
     }
-
 }

--- a/tests/MatchTest.php
+++ b/tests/MatchTest.php
@@ -63,4 +63,20 @@ class MatchTest extends PHPUnit_Framework_TestCase
 
         Regex::match('/(a)bc/', 'abcdef')->group(2);
     }
+
+    /** @test */
+    public function it_can_retrieve_a_matched_group_by_name()
+    {
+        $this->assertEquals('a', Regex::match('/(?P<mygroup>a)bc/', 'abcdef')->namedGroup('mygroup'));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_a_non_existing_named_group_is_queried()
+    {
+        $this->expectException(RegexFailed::class);
+        $this->expectExceptionMessage(RegexFailed::namedGroupDoesntExist('/(?P<mygroup>a)bc/', 'abcdef', 'othergroup')->getMessage());
+
+        Regex::match('/(?P<mygroup>a)bc/', 'abcdef')->namedGroup('othergroup');
+    }
+
 }

--- a/tests/RegexBuilderTest.php
+++ b/tests/RegexBuilderTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Spatie\Regex\Test;
+
+use Spatie\Regex\Builder\ExpressionBuilder;
+use Spatie\Regex\Builder\RegexBuilder;
+use Spatie\Regex\Regex;
+use Spatie\Regex\RegexFailed;
+
+/**
+ * Class RegexBuilderTest
+ *
+ * @package Spatie\Regex\Test
+ */
+class RegexBuilderTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @test */
+    function it_builds_a_regex()
+    {
+        $builder = RegexBuilder::create();
+        $this->assertEquals('//', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_throws_an_exception_on_invalid_regex()
+    {
+        $builder = RegexBuilder::create();
+        $builder->addExpression('InvalidRegular)Expression');
+        $this->expectException(RegexFailed::class);
+        $this->assertEquals('//', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_add_expression_parts()
+    {
+        $builder = RegexBuilder::create();
+        $builder->addExpression('(otherpart)');
+        $this->assertEquals('/(otherpart)/', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_anchor_starting_expressions()
+    {
+        $builder = RegexBuilder::create();
+        $builder->startsWith('^start');
+        $builder->addExpression('(otherpart)');
+        $this->assertEquals('/^start(otherpart)/', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_anchor_ending_expressions()
+    {
+        $builder = RegexBuilder::create();
+        $builder->endsWith('end$');
+        $builder->addExpression('(otherpart)');
+        $this->assertEquals('/(otherpart)end$/', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_anchor_both_start_and_ending_expressions()
+    {
+        $builder = RegexBuilder::create();
+        $builder->startsWith('^start');
+        $builder->endsWith('end$');
+        $builder->addExpression('(otherpart)');
+        $this->assertEquals('/^start(otherpart)end$/', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_add_a_modifier()
+    {
+        $builder = RegexBuilder::create();
+        $builder->addModifier(Regex::MODIFIER_MULTILINE);
+        $this->assertEquals('//m', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_knows_modifier_is_added()
+    {
+        $builder = RegexBuilder::create();
+        $builder->addModifier(Regex::MODIFIER_MULTILINE);
+        $this->assertTrue($builder->hasModifier(Regex::MODIFIER_MULTILINE));
+        $this->assertFalse($builder->hasModifier(Regex::MODIFIER_SINGLE_LINE));
+    }
+
+    /** @test */
+    function it_can_not_add_multi_char_modifier()
+    {
+        $builder = RegexBuilder::create();
+        $this->expectException(RegexFailed::class);
+        $builder->addModifier('invalid');
+    }
+
+    /** @test */
+    function it_can_not_add_unsupported_modifier()
+    {
+        $builder = RegexBuilder::create();
+        $this->expectException(RegexFailed::class);
+        $builder->addModifier('z');
+    }
+
+    /** @test */
+    function it_can_add_multiple_modifiers()
+    {
+        $builder = RegexBuilder::create();
+        $builder->addModifiers([Regex::MODIFIER_MULTILINE, Regex::MODIFIER_FREE_SPACING_MODE]);
+        $this->assertEquals('//mx', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_remove_modifiers()
+    {
+        $builder = RegexBuilder::create();
+        $builder->addModifier(Regex::MODIFIER_MULTILINE);
+        $builder->removeModifier(Regex::MODIFIER_MULTILINE);
+        $this->assertEquals('//', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_mark_as_case_insensitive()
+    {
+        $builder = RegexBuilder::create();
+        $builder->isCaseInsensitive();
+        $this->assertEquals('//i', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_mark_as_multiline()
+    {
+        $builder = RegexBuilder::create();
+        $builder->isMultiline();
+        $this->assertEquals('//m', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_mark_as_unicode()
+    {
+        $builder = RegexBuilder::create();
+        $builder->isUnicode();
+        $this->assertEquals('//u', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_mark_as_free_spacing()
+    {
+        $builder = RegexBuilder::create();
+        $builder->isFreeSpacing();
+        $this->assertEquals('//x', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_set_a_delimiter()
+    {
+        $builder = RegexBuilder::create();
+        $builder->setDelimiter('#');
+        $this->assertEquals('##', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_use_bracket_delimiters()
+    {
+        $builder = RegexBuilder::create();
+
+        $builder->setDelimiter('{');
+        $this->assertEquals('{}', $builder->getRegex());
+
+        $builder->setDelimiter('[');
+        $this->assertEquals('[]', $builder->getRegex());
+
+        $builder->setDelimiter('<');
+        $this->assertEquals('<>', $builder->getRegex());
+
+        $builder->setDelimiter('(');
+        $this->assertEquals('()', $builder->getRegex());
+    }
+
+    /** @test */
+    function it_can_not_set_an_multi_character_delimiter()
+    {
+        $this->expectException(RegexFailed::class);
+
+        $builder = RegexBuilder::create();
+        $builder->setDelimiter('##');
+    }
+
+    /** @test */
+    function it_can_output_multiline_regexes()
+    {
+        $builder = RegexBuilder::create();
+        $expr = ExpressionBuilder::create();
+        $builder
+            ->isFreeSpacing()
+            ->addExpression($expr->extendedComment('This one matches everything'))
+            ->addExpression($expr->group('.*'))
+        ;
+
+        $expected = <<<EOF
+/
+# This one matches everything
+(.*)
+/x
+EOF;
+
+        $this->assertEquals($expected, $builder->getRegex("\n"));
+    }
+}

--- a/tests/RegexBuilderTest.php
+++ b/tests/RegexBuilderTest.php
@@ -7,23 +7,17 @@ use Spatie\Regex\Builder\RegexBuilder;
 use Spatie\Regex\Regex;
 use Spatie\Regex\RegexFailed;
 
-/**
- * Class RegexBuilderTest
- *
- * @package Spatie\Regex\Test
- */
 class RegexBuilderTest extends \PHPUnit_Framework_TestCase
 {
-
     /** @test */
-    function it_builds_a_regex()
+    public function it_builds_a_regex()
     {
         $builder = RegexBuilder::create();
         $this->assertEquals('//', $builder->getRegex());
     }
 
     /** @test */
-    function it_throws_an_exception_on_invalid_regex()
+    public function it_throws_an_exception_on_invalid_regex()
     {
         $builder = RegexBuilder::create();
         $builder->addExpression('InvalidRegular)Expression');
@@ -32,7 +26,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_add_expression_parts()
+    public function it_can_add_expression_parts()
     {
         $builder = RegexBuilder::create();
         $builder->addExpression('(otherpart)');
@@ -40,7 +34,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_anchor_starting_expressions()
+    public function it_can_anchor_starting_expressions()
     {
         $builder = RegexBuilder::create();
         $builder->startsWith('^start');
@@ -49,7 +43,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_anchor_ending_expressions()
+    public function it_can_anchor_ending_expressions()
     {
         $builder = RegexBuilder::create();
         $builder->endsWith('end$');
@@ -58,7 +52,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_anchor_both_start_and_ending_expressions()
+    public function it_can_anchor_both_start_and_ending_expressions()
     {
         $builder = RegexBuilder::create();
         $builder->startsWith('^start');
@@ -68,7 +62,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_add_a_modifier()
+    public function it_can_add_a_modifier()
     {
         $builder = RegexBuilder::create();
         $builder->addModifier(Regex::MODIFIER_MULTILINE);
@@ -76,7 +70,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_knows_modifier_is_added()
+    public function it_knows_modifier_is_added()
     {
         $builder = RegexBuilder::create();
         $builder->addModifier(Regex::MODIFIER_MULTILINE);
@@ -85,7 +79,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_not_add_multi_char_modifier()
+    public function it_can_not_add_multi_char_modifier()
     {
         $builder = RegexBuilder::create();
         $this->expectException(RegexFailed::class);
@@ -93,7 +87,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_not_add_unsupported_modifier()
+    public function it_can_not_add_unsupported_modifier()
     {
         $builder = RegexBuilder::create();
         $this->expectException(RegexFailed::class);
@@ -101,7 +95,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_add_multiple_modifiers()
+    public function it_can_add_multiple_modifiers()
     {
         $builder = RegexBuilder::create();
         $builder->addModifiers([Regex::MODIFIER_MULTILINE, Regex::MODIFIER_FREE_SPACING_MODE]);
@@ -109,7 +103,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_remove_modifiers()
+    public function it_can_remove_modifiers()
     {
         $builder = RegexBuilder::create();
         $builder->addModifier(Regex::MODIFIER_MULTILINE);
@@ -118,7 +112,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_mark_as_case_insensitive()
+    public function it_can_mark_as_case_insensitive()
     {
         $builder = RegexBuilder::create();
         $builder->isCaseInsensitive();
@@ -126,7 +120,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_mark_as_multiline()
+    public function it_can_mark_as_multiline()
     {
         $builder = RegexBuilder::create();
         $builder->isMultiline();
@@ -134,7 +128,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_mark_as_unicode()
+    public function it_can_mark_as_unicode()
     {
         $builder = RegexBuilder::create();
         $builder->isUnicode();
@@ -142,7 +136,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_mark_as_free_spacing()
+    public function it_can_mark_as_free_spacing()
     {
         $builder = RegexBuilder::create();
         $builder->isFreeSpacing();
@@ -150,7 +144,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_set_a_delimiter()
+    public function it_can_set_a_delimiter()
     {
         $builder = RegexBuilder::create();
         $builder->setDelimiter('#');
@@ -158,7 +152,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_use_bracket_delimiters()
+    public function it_can_use_bracket_delimiters()
     {
         $builder = RegexBuilder::create();
 
@@ -176,7 +170,7 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_not_set_an_multi_character_delimiter()
+    public function it_can_not_set_an_multi_character_delimiter()
     {
         $this->expectException(RegexFailed::class);
 
@@ -185,17 +179,16 @@ class RegexBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_can_output_multiline_regexes()
+    public function it_can_output_multiline_regexes()
     {
         $builder = RegexBuilder::create();
         $expr = ExpressionBuilder::create();
         $builder
             ->isFreeSpacing()
             ->addExpression($expr->extendedComment('This one matches everything'))
-            ->addExpression($expr->group('.*'))
-        ;
+            ->addExpression($expr->group('.*'));
 
-        $expected = <<<EOF
+        $expected = <<<'EOF'
 /
 # This one matches everything
 (.*)


### PR DESCRIPTION
This PR contains a `RegexBuilder` and an `ExpressionBuilder` that makes it easy to generate regular expressions programmatically. It makes it easy to understand previously written regexes, to use advanced expressions and to tell what the regex is doing to beginning regex programmers.

Example:

```php
$builder = RegexBuilder::create();
$expr = ExpressionBuilder::create();
$regex = $builder
    ->setDelimiter('/')
    ->isCaseInsensitive()
    ->isFreeSpacing()
    ->addExpression($expr->extendedComment('This one matches zero or more numeric characters.'))
    ->addExpression(
        $exp->concat(
            $exp->characterClass(
                $exp->concat(
                    $exp->range('0', '9'),
                    $exp->range('a', 'z')
                )
            ),
            $exp->zeroOrMoreTimes()
        )
    )
    ->getRegex("\n");
```

Result
```
/
# This one matches zero or more numeric characters.
[0-9a-z]*
/ix
```

(Off course the example above is simple and can be written directly as the result, but some advanced expressions are also available with the builder.)

It's based on this presentation:
http://slides.seld.be/?file=2016-01-30+How+I+learned+to+stop+worrying+and+love+Regular+Expressions.html#1

If this is something you want inside this package, I can add some additional documentation on how to use it.

(Side-Note: I thing the current Regex class should really be a Regex instance instead of a list with static functions. It makes more sense to me)