### PR TITLE
Support for named capturing groups in MatchAllResult

### DIFF
--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -19,18 +19,18 @@ class Arr
             }, $array);
         }
 
-        $numHits = \count($array[0]);
-        $groups  = array_keys($array);
-        $r       = [];
+        $numHits = count($array[0]);
+        $groups = array_keys($array);
+        $result = [];
         for ($hit = 0; $hit < $numHits; ++$hit) {
             $group = [];
             foreach ($groups as $groupName) {
                 $group[$groupName] = $array[$groupName][$hit];
             }
-            $r[] = $group;
+            $result[] = $group;
         }
 
-        return $r;
+        return $result;
     }
 
     /**

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -19,7 +19,18 @@ class Arr
             }, $array);
         }
 
-        return array_map(null, ...$array);
+        $numHits = \count($array[0]);
+        $groups  = array_keys($array);
+        $r       = [];
+        for ($hit = 0; $hit < $numHits; ++$hit) {
+            $group = [];
+            foreach ($groups as $groupName) {
+                $group[$groupName] = $array[$groupName][$hit];
+            }
+            $r[] = $group;
+        }
+
+        return $r;
     }
 
     /**

--- a/src/MatchAllResult.php
+++ b/src/MatchAllResult.php
@@ -58,7 +58,7 @@ class MatchAllResult extends RegexResult
     }
 
     /**
-     * @return MatchResult[]
+     * @return \Spatie\Regex\MatchResult[]
      */
     public function results(): array
     {

--- a/src/MatchAllResult.php
+++ b/src/MatchAllResult.php
@@ -57,6 +57,9 @@ class MatchAllResult extends RegexResult
         return $this->hasMatch;
     }
 
+    /**
+     * @return MatchResult[]
+     */
     public function results(): array
     {
         return Arr::map(Arr::transpose($this->matches), function ($match): MatchResult {

--- a/src/MatchResult.php
+++ b/src/MatchResult.php
@@ -75,7 +75,7 @@ class MatchResult extends RegexResult
     }
 
     /**
-     * Match group by index.
+     * Match group by index or name.
      *
      * @param int|string $group
      *
@@ -99,6 +99,8 @@ class MatchResult extends RegexResult
      * @param string     $default
      *
      * @return string
+     *
+     * @throws RegexFailed
      */
     public function groupOr($group, $default): string
     {
@@ -110,20 +112,16 @@ class MatchResult extends RegexResult
     }
 
     /**
-     * Match group by name.
+     * Match group by index or name.
      *
-     * @param int|string $groupName
+     * @param int|string $group
      *
      * @return string
      *
      * @throws RegexFailed
      */
-    public function namedGroup($groupName): string
+    public function namedGroup($group): string
     {
-        if (! isset($this->matches[$groupName])) {
-            throw RegexFailed::groupDoesntExist($this->pattern, $this->subject, $groupName);
-        }
-
-        return $this->matches[$groupName];
+    	  return $this->group($group);
     }
 }

--- a/src/MatchResult.php
+++ b/src/MatchResult.php
@@ -77,35 +77,33 @@ class MatchResult extends RegexResult
     /**
      * Match group by index.
      *
-     * @param int $index
+     * @param int|string $group
      *
      * @return string
      *
      * @throws RegexFailed
      */
-    public function group(int $index): string
+    public function group($group): string
     {
-        if (! isset($this->matches[$index])) {
-            throw RegexFailed::indexedGroupDoesntExist($this->pattern, $this->subject, $index);
+        if (! isset($this->matches[$group])) {
+            throw RegexFailed::groupDoesntExist($this->pattern, $this->subject, $group);
         }
 
-        return $this->matches[$index];
+        return $this->matches[$group];
     }
 
     /**
      * Match group by index or return default value if group doesn't exist.
      *
-     * @param int $index
-     * @param string $default
+     * @param int|string $group
+     * @param string     $default
      *
      * @return string
-     *
-     * @throws RegexFailed
      */
-    public function groupOr(int $index, $default): string
+    public function groupOr($group, $default): string
     {
         try {
-            return $this->group($index);
+            return $this->group($group);
         } catch (RegexFailed $e) {
             return $default;
         }
@@ -114,16 +112,16 @@ class MatchResult extends RegexResult
     /**
      * Match group by name.
      *
-     * @param string $groupName
+     * @param int|string $groupName
      *
      * @return string
      *
      * @throws RegexFailed
      */
-    public function namedGroup(string $groupName): string
+    public function namedGroup($groupName): string
     {
         if (! isset($this->matches[$groupName])) {
-            throw RegexFailed::namedGroupDoesntExist($this->pattern, $this->subject, $groupName);
+            throw RegexFailed::groupDoesntExist($this->pattern, $this->subject, $groupName);
         }
 
         return $this->matches[$groupName];

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -9,6 +9,8 @@ class Regex
      * @param string $subject
      *
      * @return \Spatie\Regex\MatchResult
+     *
+     * @throws RegexFailed
      */
     public static function match(string $pattern, string $subject): MatchResult
     {
@@ -20,6 +22,8 @@ class Regex
      * @param string $subject
      *
      * @return \Spatie\Regex\MatchAllResult
+     *
+     * @throws RegexFailed
      */
     public static function matchAll(string $pattern, string $subject): MatchAllResult
     {
@@ -27,12 +31,14 @@ class Regex
     }
 
     /**
-     * @param string|array $pattern
+     * @param string|array          $pattern
      * @param string|array|callable $replacement
-     * @param string|array $subject
-     * @param int $limit
+     * @param string|array          $subject
+     * @param int                   $limit
      *
      * @return \Spatie\Regex\ReplaceResult
+     *
+     * @throws RegexFailed
      */
     public static function replace($pattern, $replacement, $subject, $limit = -1): ReplaceResult
     {

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -9,8 +9,6 @@ class Regex
      * @param string $subject
      *
      * @return \Spatie\Regex\MatchResult
-     *
-     * @throws RegexFailed
      */
     public static function match(string $pattern, string $subject): MatchResult
     {
@@ -22,8 +20,6 @@ class Regex
      * @param string $subject
      *
      * @return \Spatie\Regex\MatchAllResult
-     *
-     * @throws RegexFailed
      */
     public static function matchAll(string $pattern, string $subject): MatchAllResult
     {
@@ -31,14 +27,12 @@ class Regex
     }
 
     /**
-     * @param string|array          $pattern
+     * @param string|array $pattern
      * @param string|array|callable $replacement
-     * @param string|array          $subject
-     * @param int                   $limit
+     * @param string|array $subject
+     * @param int $limit
      *
      * @return \Spatie\Regex\ReplaceResult
-     *
-     * @throws RegexFailed
      */
     public static function replace($pattern, $replacement, $subject, $limit = -1): ReplaceResult
     {

--- a/src/RegexFailed.php
+++ b/src/RegexFailed.php
@@ -20,14 +20,9 @@ class RegexFailed extends Exception
         return new static("Error replacing pattern `{$pattern}` in subject `{$subject}`. {$message}");
     }
 
-    public static function indexedGroupDoesntExist(string $pattern, string $subject, int $index): self
+    public static function groupDoesntExist(string $pattern, string $subject, $group): self
     {
-        return new static("Pattern `{$pattern}` with subject `{$subject}` didn't capture a group at index {$index}");
-    }
-
-    public static function namedGroupDoesntExist(string $pattern, string $subject, string $groupName): self
-    {
-        return new static("Pattern `{$pattern}` with subject `{$subject}` didn't capture a group named {$groupName}");
+        return new static("Pattern `{$pattern}` with subject `{$subject}` didn't capture a group named {$group}");
     }
 
     protected static function trimString(string $string): string

--- a/src/ReplaceResult.php
+++ b/src/ReplaceResult.php
@@ -31,14 +31,12 @@ class ReplaceResult extends RegexResult
     }
 
     /**
-     * @param string|array          $pattern
+     * @param string|array $pattern
      * @param string|array|callable $replacement
-     * @param string|array          $subject
-     * @param int                   $limit
+     * @param string|array $subject
+     * @param int $limit
      *
-     * @return ReplaceResult
-     *
-     * @throws RegexFailed
+     * @return \Spatie\Regex\ReplaceResult
      */
     public static function for($pattern, $replacement, $subject, $limit)
     {

--- a/src/ReplaceResult.php
+++ b/src/ReplaceResult.php
@@ -30,6 +30,16 @@ class ReplaceResult extends RegexResult
         $this->count = $count;
     }
 
+    /**
+     * @param string|array          $pattern
+     * @param string|array|callable $replacement
+     * @param string|array          $subject
+     * @param int                   $limit
+     *
+     * @return ReplaceResult
+     *
+     * @throws RegexFailed
+     */
     public static function for($pattern, $replacement, $subject, $limit)
     {
         try {

--- a/tests/MatchAllTest.php
+++ b/tests/MatchAllTest.php
@@ -65,4 +65,32 @@ class MatchAllTest extends TestCase
         $this->assertEquals('ab', $results[1]->result());
         $this->assertEquals('b', $results[1]->group(1));
     }
+
+    /** @test */
+    public function it_can_match_multiple_named_groups()
+    {
+        $results = Regex::matchAll('/the sky is (?<color>.+)/', <<<'TEXT'
+the sky is blue
+foo bar
+the sky is green
+the sky is red
+bar baz
+the sky is white
+TEXT
+        )->results();
+
+        $this->assertCount(4, $results);
+        $this->assertEquals('the sky is blue', $results[0]->result());
+        $this->assertEquals('blue', $results[0]->group('color'));
+        $this->assertEquals('blue', $results[0]->group(1));
+        $this->assertEquals('the sky is green', $results[1]->result());
+        $this->assertEquals('green', $results[1]->group('color'));
+        $this->assertEquals('green', $results[1]->group(1));
+        $this->assertEquals('the sky is red', $results[2]->result());
+        $this->assertEquals('red', $results[2]->group('color'));
+        $this->assertEquals('red', $results[2]->group(1));
+        $this->assertEquals('the sky is white', $results[3]->result());
+        $this->assertEquals('white', $results[3]->group('color'));
+        $this->assertEquals('white', $results[3]->group(1));
+    }
 }

--- a/tests/MatchTest.php
+++ b/tests/MatchTest.php
@@ -59,7 +59,7 @@ class MatchTest extends TestCase
     public function it_throws_an_exception_if_a_non_existing_group_is_queried()
     {
         $this->expectException(RegexFailed::class);
-        $this->expectExceptionMessage(RegexFailed::indexedGroupDoesntExist('/(a)bc/', 'abcdef', 2)->getMessage());
+        $this->expectExceptionMessage(RegexFailed::groupDoesntExist('/(a)bc/', 'abcdef', 2)->getMessage());
 
         Regex::match('/(a)bc/', 'abcdef')->group(2);
     }
@@ -75,7 +75,7 @@ class MatchTest extends TestCase
     {
         $this->expectException(RegexFailed::class);
         $this->expectExceptionMessage(
-            RegexFailed::namedGroupDoesntExist('/(?<samename>a)bc/', 'abcdef', 'invalidname')->getMessage()
+            RegexFailed::groupDoesntExist('/(?<samename>a)bc/', 'abcdef', 'invalidname')->getMessage()
         );
 
         Regex::match('/(?<samename>a)bc/', 'abcdef')->namedGroup('invalidname');


### PR DESCRIPTION
I added support for named capturing groups in class `MatchAllResult`. The old behavior has been done with `array_map()` but it's not compatible with string keys inside arrays, so they can't be unpacked. I therefore reworked it and now named capturing groups in regular expressions can be used on `Regex::matchAll()` also.

As an additional change I reworked `MatchResult::group()` and `MatchResult::namedGroup()`. I don't see why I need to distinguish between indexed and named capturing groups, because probably if using named capturing groups they can be the same. I think there's no need to differentiate between both.

Additionally I type hinted `MatchAllResult::results()` to get a useful code completion.

I also annotated necessary `@throws` tags where an exception could be thrown.