### PR TITLE
Fix determining the last preg error

### DIFF
--- a/src/RegexResult.php
+++ b/src/RegexResult.php
@@ -6,6 +6,6 @@ abstract class RegexResult
 {
     protected static function lastPregError(): string
     {
-        return array_flip(get_defined_constants(true)['pcre'])[preg_last_error()];
+        return array_search(preg_last_error(), get_defined_constants(true)['pcre'], true);
     }
 }


### PR DESCRIPTION
PHP 7.3 introduced a new boolean constant `PCRE_JIT_SUPPORT` (https://3v4l.org/7iHtT), which means that the `array_flip` was failing due to `Can only flip STRING and INTEGER values!`. We can simply replace this code with an `array_search`, and we're in the clear.

Before: https://3v4l.org/IcQPW
After: https://3v4l.org/UmWhC

---

Closes #30 