### PR TITLE
Add support for offset in regex matches

### DIFF
--- a/src/OffsetGroup.php
+++ b/src/OffsetGroup.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\Regex;
+
+/**
+ * The content of a regex match group together with its offset.
+ */
+class OffsetGroup
+{
+    /** @var string */
+    protected $content;
+
+    /** @var int */
+    protected $offset;
+
+    public function __construct(string $content, int $offset)
+    {
+        $this->content = $content;
+        $this->offset = $offset;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+}

--- a/src/OffsetMatchResult.php
+++ b/src/OffsetMatchResult.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Spatie\Regex;
+
+use Exception;
+
+class OffsetMatchResult extends RegexResult
+{
+    /** @var string */
+    protected $pattern;
+
+    /** @var string */
+    protected $subject;
+
+    /** @var bool */
+    protected $hasMatch;
+
+    /** @var OffsetGroup[] */
+    protected $matches;
+
+    public function __construct(string $pattern, string $subject, bool $hasMatch, array $matches)
+    {
+        $this->pattern = $pattern;
+        $this->subject = $subject;
+        $this->hasMatch = $hasMatch;
+        $this->matches = $matches;
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $subject
+     *
+     * @return static
+     *
+     * @throws \Spatie\Regex\RegexFailed
+     */
+    public static function for(string $pattern, string $subject)
+    {
+        $matches = [];
+
+        try {
+            $result = preg_match($pattern, $subject, $matches, PREG_OFFSET_CAPTURE);
+        } catch (Exception $exception) {
+            throw RegexFailed::match($pattern, $subject, $exception->getMessage());
+        }
+
+        if ($result === false) {
+            throw RegexFailed::match($pattern, $subject, static::lastPregError());
+        }
+
+        $realMatches = array_filter($matches, function (array $group) {
+            return $group[1] !== -1;
+        });
+
+        $offsetGroups = array_map(function ($group) {
+            return new OffsetGroup($group[0], $group[1]);
+        }, $realMatches);
+
+        return new static($pattern, $subject, $result, $offsetGroups);
+    }
+
+    public function hasMatch(): bool
+    {
+        return $this->hasMatch;
+    }
+
+    /**
+     * @return OffsetGroup|null
+     */
+    public function result()
+    {
+        return $this->matches[0] ?? null;
+    }
+
+    /**
+     * Match group by index or name.
+     *
+     * @param int|string $group
+     *
+     * @return string
+     *
+     * @throws RegexFailed
+     */
+    public function group($group): OffsetGroup
+    {
+        if (! isset($this->matches[$group])) {
+            throw RegexFailed::groupDoesntExist($this->pattern, $this->subject, $group);
+        }
+
+        return $this->matches[$group];
+    }
+
+    /**
+     * Return an array of the matches.
+     *
+     * @return OffsetGroup[]
+     */
+    public function groups(): array
+    {
+        return $this->matches;
+    }
+
+    /**
+     * Match group by index or name.
+     *
+     * @param int|string $group
+     *
+     * @return string
+     *
+     * @throws RegexFailed
+     */
+    public function namedGroup($group): OffsetGroup
+    {
+        return $this->group($group);
+    }
+}

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -27,6 +27,17 @@ class Regex
     }
 
     /**
+     * @param string $pattern
+     * @param string $subject
+     *
+     * @return \Spatie\Regex\OffsetMatchResult
+     */
+    public static function matchWithOffset(string $pattern, string $subject): OffsetMatchResult
+    {
+        return OffsetMatchResult::for($pattern, $subject);
+    }
+
+    /**
      * @param string|array $pattern
      * @param string|array|callable $replacement
      * @param string|array $subject

--- a/tests/OffsetMatchTest.php
+++ b/tests/OffsetMatchTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Spatie\Regex\Test;
+
+use Spatie\Regex\Regex;
+use Spatie\Regex\OffsetGroup;
+use Spatie\Regex\RegexFailed;
+use PHPUnit\Framework\TestCase;
+
+class OffsetMatchTest extends TestCase
+{
+    /** @test */
+    public function it_can_determine_if_a_match_was_made()
+    {
+        $this->assertTrue(Regex::matchWithOffset('/abc/', 'abc')->hasMatch());
+        $this->assertFalse(Regex::matchWithOffset('/abc/', 'def')->hasMatch());
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_a_match_throws_an_error()
+    {
+        $this->expectException(RegexFailed::class);
+        $this->expectExceptionMessage(
+            RegexFailed::match('/abc', 'abc', 'preg_match(): No ending delimiter \'/\' found')->getMessage()
+        );
+
+        Regex::matchWithOffset('/abc', 'abc');
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_a_match_throws_a_preg_error()
+    {
+        $this->expectException(RegexFailed::class);
+        $this->expectExceptionMessage(
+            RegexFailed::match('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar', 'PREG_BACKTRACK_LIMIT_ERROR')->getMessage()
+        );
+
+        Regex::matchWithOffset('/(?:\D+|<\d+>)*[!?]/', 'foobar foobar foobar');
+    }
+
+    /** @test */
+    public function it_can_retrieve_the_matched_result()
+    {
+        $expected = new OffsetGroup('cde', 2);
+
+        $this->assertEquals($expected, Regex::matchWithOffset('/cde/', 'abcdef')->result());
+    }
+
+    /** @test */
+    public function it_returns_null_if_a_result_is_queried_for_a_subject_that_didnt_match_a_pattern()
+    {
+        $this->assertNull(Regex::matchWithOffset('/abc/', 'def')->result());
+    }
+
+    /** @test */
+    public function it_can_retrieve_a_matched_group()
+    {
+        $expected = new OffsetGroup('b', 1);
+
+        $this->assertEquals($expected, Regex::matchWithOffset('/a(b)c/', 'abcdef')->group(1));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_a_non_existing_group_is_queried()
+    {
+        $this->expectException(RegexFailed::class);
+        $this->expectExceptionMessage(RegexFailed::groupDoesntExist('/(a)bc/', 'abcdef', 2)->getMessage());
+
+        Regex::matchWithOffset('/(a)bc/', 'abcdef')->group(2);
+    }
+
+    /** @test */
+    public function it_can_retrieve_a_matched_named_group()
+    {
+        $expected = new OffsetGroup('a', 0);
+
+        $this->assertEquals($expected, Regex::matchWithOffset('/(?<samename>a)bc/', 'abcdef')->namedGroup('samename'));
+    }
+
+    /** @test */
+    public function it_can_retrieve_all_matched_groups()
+    {
+        $results = Regex::matchWithOffset('/(c)de/', 'abcdef')->groups();
+
+        $this->assertCount(2, $results);
+
+        $expected0 = new OffsetGroup('cde', 2);
+        $this->assertEquals($expected0, $results[0]);
+
+        $expected1 = new OffsetGroup('c', 2);
+        $this->assertEquals($expected1, $results[1]);
+    }
+
+    /** @test */
+    public function it_throws_an_exception_if_a_non_existing_named_group_is_queued()
+    {
+        $this->expectException(RegexFailed::class);
+        $this->expectExceptionMessage(
+            RegexFailed::groupDoesntExist('/(?<samename>a)bc/', 'abcdef', 'invalidname')->getMessage()
+        );
+
+        Regex::matchWithOffset('/(?<samename>a)bc/', 'abcdef')->namedGroup('invalidname');
+    }
+}


### PR DESCRIPTION
Re-submit of #36 

Uses the flag PREG_OFFSET_CAPTURE.

I copied MatchResult and changed the following:

- Replaced result type string by OffsetGroup which holds a string match and the associated offset
- Removed non-matched groups because there is no useful offset. The caller will want to check for its absence using `isset($result->groups()[$name])` or catching `RegexFailed`. This is a bit clumsy if you don't care about the offset for some matches but seems like more sane behaviour than returning offset -1 like preg_match does.
- Removed the methods groupOr and resultOr because they don't make sense if you need the offset.
